### PR TITLE
Added bind to console.log to avoid illegal invocation error con chrom…

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,7 +6,15 @@ var sendCommand = require('./lib/sendCommand');
 var stk500 = function (opts) {
   this.opts = opts || {};
   this.quiet = this.opts.quiet || false;
-  this.log = (this.quiet) ? function(){} : console.log.bind(window);
+  if(this.quiet){
+    this.log = function(){};
+  }else{
+    if(window){
+      this.log = console.log.bind(window);
+    }else{
+      this.log = console.log;
+    }
+  }
 }
 
 stk500.prototype.sync = function (stream, attempts, timeout, done) {

--- a/index.js
+++ b/index.js
@@ -6,7 +6,7 @@ var sendCommand = require('./lib/sendCommand');
 var stk500 = function (opts) {
   this.opts = opts || {};
   this.quiet = this.opts.quiet || false;
-  this.log = (this.quiet) ? function(){} : console.log;
+  this.log = (this.quiet) ? function(){} : console.log.bind(window);
 }
 
 stk500.prototype.sync = function (stream, attempts, timeout, done) {
@@ -55,7 +55,11 @@ stk500.prototype.verifySignature = function (stream, signature, timeout, done) {
     timeout: timeout
   };
   sendCommand(stream, opt, function (err, data) {
-		self.log('confirm signature', err, data, data.toString('hex'));
+    if(data){
+      self.log('confirm signature', err, data, data.toString('hex'));
+    }else{
+      self.log('confirm signature', err, 'no data');
+    }
     done(err, data);
   });
 };


### PR DESCRIPTION
Hi!
Im working to give support to Bitbloq in a Spanish Linux distribution called Guadalinex Edu.

 But i got some errors, the first its a illegal invocation error when self.log is called, its strange, but cant reproduce the error on another linux distribution, only appear using chromium in that linux distribution, i try on 3  pcs an the same error, but chromium or chrome on mac or ubuntu works fine. I get that fix on [stack overflow](http://stackoverflow.com/questions/9677985/uncaught-typeerror-illegal-invocation-in-chrome) , and it works. 

The second error happens in this distribution too, and its a logged message transformed to String, but sometimes the data content its empty. The upload works, but data appear empty and fails doing data.toString(). So i just added an if.

I see that avrgirl-arduino use this branch so i upload the pull request here. The original branch its deprecated?  i open a issue for help time ago,  but never response :(
Or i should do the open request on jacob rosenthal repo too? 

Thanks!